### PR TITLE
Add Netlify forms workaround for Next.js runtime

### DIFF
--- a/components/contact-section.tsx
+++ b/components/contact-section.tsx
@@ -1,4 +1,51 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+
+type SubmissionState = "idle" | "success" | "error";
+
 export function ContactSection() {
+  const [status, setStatus] = useState<SubmissionState>("idle");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setStatus("idle");
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const encodedBody = new URLSearchParams();
+
+    formData.forEach((value, key) => {
+      if (typeof value === "string") {
+        encodedBody.append(key, value);
+      }
+    });
+
+    try {
+      const response = await fetch("/__forms.html", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: encodedBody.toString(),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Unexpected response ${response.status}`);
+      }
+
+      form.reset();
+      setStatus("success");
+    } catch (error) {
+      console.error("Failed to submit contact form", error);
+      setStatus("error");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
   return (
     <section
       id="contact"
@@ -14,6 +61,8 @@ export function ContactSection() {
         name="project-inquiry"
         method="post"
         data-netlify="true"
+        onSubmit={handleSubmit}
+        noValidate
       >
         <input type="hidden" name="form-name" value="project-inquiry" />
         <label className="flex flex-col text-sm font-medium text-night/70">
@@ -44,10 +93,21 @@ export function ContactSection() {
         </label>
         <button
           type="submit"
-          className="md:col-span-2 inline-flex w-fit items-center rounded-full bg-night px-6 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-ivory transition-transform duration-200 hover:-translate-y-0.5"
+          className="md:col-span-2 inline-flex w-fit items-center rounded-full bg-night px-6 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-ivory transition-transform duration-200 hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-70"
+          disabled={isSubmitting}
         >
-          Send message
+          {isSubmitting ? "Sending…" : "Send message"}
         </button>
+        {status === "success" && (
+          <p className="md:col-span-2 text-sm text-green-600" role="status">
+            Thank you! I’ll be in touch within two business days.
+          </p>
+        )}
+        {status === "error" && (
+          <p className="md:col-span-2 text-sm text-red-600" role="alert">
+            Something went wrong. Please try again or email me directly.
+          </p>
+        )}
       </form>
     </section>
   );

--- a/public/__forms.html
+++ b/public/__forms.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Netlify form registration</title>
+  </head>
+  <body>
+    <form name="project-inquiry" method="post" data-netlify="true" hidden>
+      <input type="hidden" name="form-name" value="project-inquiry" />
+      <input type="text" name="name" />
+      <input type="email" name="email" />
+      <textarea name="message"></textarea>
+    </form>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a client-side submission handler for the contact form that posts to the Netlify forms registration endpoint and reports submission status
- register the Netlify form fields in a hidden static HTML file so the build can detect the form at deploy time

## Testing
- npm run lint *(fails: Next.js prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e61b3d9a04832ea2bfbd6de1614b46